### PR TITLE
Add retro 2000s homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retro 2001 Home Page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <table class="page" cellspacing="0" cellpadding="0">
+      <tr>
+        <td class="sidebar">
+          <div class="logo-box">
+            <div class="logo">Y2K</div>
+            <div class="logo-sub">Welcome!</div>
+          </div>
+          <div class="nav-box">
+            <div class="nav-title">Menu</div>
+            <ul class="nav">
+              <li><a href="#news">News</a></li>
+              <li><a href="#diary">Diary</a></li>
+              <li><a href="#gallery">Gallery</a></li>
+              <li><a href="#links">Links</a></li>
+            </ul>
+          </div>
+          <div class="counter">
+            <div class="counter-title">Visitors</div>
+            <div class="digits">00012345</div>
+          </div>
+        </td>
+        <td class="main">
+          <div class="marquee">
+            <marquee behavior="alternate" scrollamount="6">★☆★ 2001年へようこそ！Flash全盛期の気分でどうぞ！★☆★</marquee>
+          </div>
+          <div class="hero">
+            <h1>わたしのレトロホームページ</h1>
+            <p class="blink">このサイトはInternet Explorer 6で最適に表示されます。</p>
+          </div>
+          <div id="news" class="content-box">
+            <h2>What’s New</h2>
+            <ul>
+              <li>2002/07/12 サイトをリニューアルしました！</li>
+              <li>2002/06/01 日記を更新しました。</li>
+              <li>2002/05/15 10000HITありがとうございます！</li>
+            </ul>
+          </div>
+          <div id="diary" class="content-box">
+            <h2>Diary</h2>
+            <p>
+              今日はレインボーな背景を追加してみました。<br />
+              ちなみにお気に入りは「MS ゴシック」です。
+            </p>
+          </div>
+          <div id="gallery" class="content-box">
+            <h2>Gallery</h2>
+            <div class="gallery">
+              <div class="thumb">GIF 1</div>
+              <div class="thumb">GIF 2</div>
+              <div class="thumb">GIF 3</div>
+              <div class="thumb">GIF 4</div>
+            </div>
+          </div>
+          <div id="links" class="content-box">
+            <h2>Links</h2>
+            <ul>
+              <li><a href="https://example.com">お気に入りサイト</a></li>
+              <li><a href="https://example.com">お友だちリンク</a></li>
+              <li><a href="https://example.com">素材屋さん</a></li>
+            </ul>
+          </div>
+          <div class="footer">
+            <p>Copyright © 2001 Retro Home Page.</p>
+            <p>Since 2001 / Last update: 2002/07/12</p>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,167 @@
+body {
+  margin: 0;
+  background: repeating-linear-gradient(
+      45deg,
+      #ff00cc 0,
+      #ff00cc 10px,
+      #00ffff 10px,
+      #00ffff 20px
+    );
+  font-family: "MS Gothic", "MS PGothic", "Courier New", monospace;
+  color: #00ff00;
+}
+
+a {
+  color: #ffff00;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: #ff00ff;
+}
+
+.page {
+  width: 980px;
+  margin: 20px auto;
+  border: 6px ridge #00ffff;
+  background: #000033;
+}
+
+.sidebar {
+  width: 200px;
+  vertical-align: top;
+  background: #000000;
+  border-right: 4px double #00ffff;
+  padding: 10px;
+}
+
+.logo-box {
+  text-align: center;
+  border: 3px outset #ff00cc;
+  padding: 10px 5px;
+  margin-bottom: 15px;
+  background: #000066;
+}
+
+.logo {
+  font-size: 36px;
+  font-weight: bold;
+  color: #ffcc00;
+  text-shadow: 2px 2px #ff00ff;
+}
+
+.logo-sub {
+  font-size: 12px;
+  color: #00ffff;
+}
+
+.nav-box {
+  border: 3px inset #00ffff;
+  padding: 8px;
+  margin-bottom: 15px;
+  background: #001144;
+}
+
+.nav-title {
+  font-weight: bold;
+  margin-bottom: 6px;
+  color: #ffcc00;
+}
+
+.nav {
+  list-style: square;
+  padding-left: 18px;
+  margin: 0;
+}
+
+.counter {
+  border: 2px dashed #ff00ff;
+  padding: 8px;
+  text-align: center;
+  background: #110022;
+}
+
+.counter-title {
+  font-size: 12px;
+  color: #00ffff;
+  margin-bottom: 4px;
+}
+
+.digits {
+  letter-spacing: 2px;
+  font-size: 16px;
+  color: #ffff00;
+}
+
+.main {
+  padding: 15px;
+  vertical-align: top;
+}
+
+.marquee {
+  border: 2px solid #00ffff;
+  background: #000000;
+  padding: 6px;
+  margin-bottom: 12px;
+  color: #ffcc00;
+}
+
+.hero {
+  border: 4px groove #ff00ff;
+  padding: 12px;
+  text-align: center;
+  background: radial-gradient(circle at top, #0033ff, #000011);
+  margin-bottom: 16px;
+}
+
+.hero h1 {
+  margin: 0 0 8px;
+  font-size: 28px;
+  color: #00ffff;
+  text-shadow: 2px 2px #ff00ff;
+}
+
+.blink {
+  color: #ffcc00;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  to {
+    visibility: hidden;
+  }
+}
+
+.content-box {
+  border: 3px outset #00ffff;
+  padding: 10px 12px;
+  margin-bottom: 15px;
+  background: #000022;
+}
+
+.content-box h2 {
+  margin-top: 0;
+  color: #ffcc00;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.thumb {
+  border: 2px solid #ff00ff;
+  padding: 10px;
+  text-align: center;
+  background: #000000;
+  color: #00ffff;
+}
+
+.footer {
+  text-align: center;
+  font-size: 12px;
+  border-top: 2px dashed #00ffff;
+  padding-top: 10px;
+  color: #ffffff;
+}


### PR DESCRIPTION
### Motivation
- Provide a nostalgic early-2000s style homepage with classic elements (sidebar, marquee, visitor counter, gallery) as requested.

### Description
- Add `index.html` implementing a table-based layout with a sidebar (logo, navigation, visitor counter) and main content sections (news, diary, gallery, links, footer).
- Add `styles.css` providing neon/repeating-gradient background, retro fonts, bold borders/shadows, a blinking text animation via `@keyframes`, and grid-based gallery styling.
- Include legacy-feeling elements such as `<marquee>` and intentionally vintage visual treatments to mimic the era.

### Testing
- Launched a local static HTTP server and used Playwright to render the page and capture a full-page screenshot, and the screenshot run completed successfully.
- No additional automated unit tests were added because the change is static HTML/CSS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dd150ff8833093a700615d6ff9fd)