### PR TITLE
Make layout fluid and add responsive breakpoint for narrow viewports

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,8 @@ a:hover {
 }
 
 .page {
-  width: 980px;
+  width: 100%;
+  max-width: 980px;
   margin: 20px auto;
   border: 6px ridge #00ffff;
   background: #000033;
@@ -164,4 +165,27 @@ a:hover {
   border-top: 2px dashed #00ffff;
   padding-top: 10px;
   color: #ffffff;
+}
+
+@media (max-width: 860px) {
+  .page,
+  .page tbody,
+  .page tr,
+  .page td {
+    display: block;
+    width: 100%;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 4px double #00ffff;
+  }
+
+  .main {
+    padding: 12px;
+  }
+
+  .gallery {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve usability on smaller screens by making the main layout fluid and adapt to narrow viewports.
- Preserve the retro visual while ensuring the sidebar and gallery stack/resize gracefully on mobile-sized devices.

### Description
- Updated `.page` to use `width: 100%` with `max-width: 980px` for a fluid, centered layout in `styles.css`.
- Added an `@media (max-width: 860px)` breakpoint that switches the table-based layout to block display so the sidebar stacks above the main content.
- Removed the sidebar's right border at the breakpoint and added a bottom border to visually separate stacked sections.
- Reduced `.gallery` columns from 4 to 2 under the breakpoint to improve thumbnail layout on narrow screens.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to capture a full-page screenshot, which completed successfully and produced `artifacts/retro-homepage.png`.
- No unit tests exist for this static CSS change; visual verification via the generated screenshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981df557ef0833091839ae1324f3c60)